### PR TITLE
Added support for file exclusions

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,6 +52,13 @@ CSSLinter.prototype.write = function (readTree, destDir) {
 }
 
 CSSLinter.prototype.processString = function (content, relativePath) {
+
+  var filesToExclude =  this.csslintrc['excluded-files'];
+
+  if(filesToExclude && filesToExclude.indexOf(relativePath) !== -1) {
+    return;
+  }
+
   var report = csslint.verify(content, this.csslintrc);
   var errors = this.processMessages(relativePath, report.messages);
 

--- a/test/fixtures/css-files-that-need-to-be-ignored/.csslintrc
+++ b/test/fixtures/css-files-that-need-to-be-ignored/.csslintrc
@@ -1,0 +1,3 @@
+{
+	"excluded-files" : "hydra/teserract.css,the-one-that-should-be-ignored.css"
+}

--- a/test/fixtures/css-files-that-need-to-be-ignored/hydra/teserract.css
+++ b/test/fixtures/css-files-that-need-to-be-ignored/hydra/teserract.css
@@ -1,0 +1,3 @@
+.red-skull{
+	background-color: red !important;
+}

--- a/test/fixtures/css-files-that-need-to-be-ignored/the-one-that-should-be-ignored.css
+++ b/test/fixtures/css-files-that-need-to-be-ignored/the-one-that-should-be-ignored.css
@@ -1,0 +1,3 @@
+.voldemort {
+	background-color: grey !important;
+}

--- a/test/fixtures/css-files-that-need-to-be-ignored/the-right-file.css
+++ b/test/fixtures/css-files-that-need-to-be-ignored/the-right-file.css
@@ -1,0 +1,3 @@
+.iron-man {
+	background-color: red;
+}

--- a/test/test.js
+++ b/test/test.js
@@ -89,4 +89,19 @@ describe('broccoli-csslint', function() {
       expect(loggerOutput.join('\n')).to.not.match(/error/);
     });
   });
+
+it('excludes files that are not meant to be a part of builds', function() {
+    var sourcePath = 'test/fixtures/css-files-that-need-to-be-ignored';
+    chdir(sourcePath);
+
+    var tree = cssLint('.', {
+      logError: function(message) { loggerOutput.push(message) }
+    });
+
+    builder = new broccoli.Builder(tree);
+    return builder.build().then(function() {
+      expect(loggerOutput.join('\n')).to.not.match(/error/);
+    });
+  });
+
 });


### PR DESCRIPTION
Was just setting up a new ember-cli project when I bumped into your plugin, great timesaver :+1: . Noticed that you invoke [verify](https://github.com/johnotander/broccoli-csslint/blob/master/index.js#L55) on the csslint module. This ignores the 'excluded-files' from the .csslintrc file. This is supported by csslint as a cli argument which does the filtering with an internal method before invoking verify.

I've made some changes, added some tests to support this in your plugin. Let me know if there's anything else required. 

Little background: ember-cli generates vendor.css and test-support.css which are linted but I want to ignore them :smile: 
