### PR TITLE
Bumped CSSLint Version to next major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "broccoli-csslint",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Add CSS linting to your Broccoli tree.",
   "main": "index.js",
   "directories": {
@@ -35,7 +35,7 @@
   "dependencies": {
     "broccoli-filter": "^0.1.14",
     "chalk": "^1.0.0",
-    "csslint": "^0.10.0",
+    "csslint": "^1.0.5",
     "findup-sync": "^0.2.1",
     "is-present": "0.0.1",
     "mkdirp": "^0.5.0"


### PR DESCRIPTION
CSSLint now above `1.0.0`
Needed as newer CSS practices (such as using plain text svgs in data uris) are being flagged as errors